### PR TITLE
Fix BubbleSort.c and factorial.c

### DIFF
--- a/Maths/Factorial/C/factorial.c
+++ b/Maths/Factorial/C/factorial.c
@@ -11,6 +11,8 @@ long long factorial(long long n) {
 }
 
 int main(int argc, char * argv[]) {
+	int n;
 	printf("Enter a number");
 	scanf("%d",&n);
+	printf("Factorial = %lld", factorial(n));
 }

--- a/Sorting/Bubble Sort/C/BubbleSort.c
+++ b/Sorting/Bubble Sort/C/BubbleSort.c
@@ -35,7 +35,6 @@ int main()
 { 
     int arr[] = {6, 4, 5, 8, 2, 1, 9}; 
     int n = sizeof(arr)/sizeof(arr[0]); 
-  scanf("%d",&n);
     bubbleSort(arr, n); 
     printArray(arr, n); 
     return 0; 


### PR DESCRIPTION
## Description
__Sorting/Bubble Sort/C/BubbleSort.c__ (issue #396)
removed the `scanf("%d",&n);` line

__Maths/Factorial/C/factorial.c__ (issue #397)
declared variable `n` before using it.
called the function `factorial`

## Related Issue
Fixing issue #396 and #397 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (change which fixes an issue with the algorithm)

- [ ] New Algorithm (non-breaking change which adds functionality)

- [ ] Documentation

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.

If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project.

- [ ] My change requires a change to the documentation.

- [ ] I have updated the documentation accordingly.

- [x] I have read the **CONTRIBUTING** document.

